### PR TITLE
Fix/dockerfile checksums

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # so every developer will have the same environment
 
 # registry.fedoraproject.org/fedora:42
-FROM registry.fedoraproject.org/fedora@sha256:27752fe47e02f243053c81456affc9cfa224047a422ffcbbbada35ba47fba21d
+FROM registry.fedoraproject.org/fedora@sha256:5a17ac8b773eac120d5f46316b196f5f6bb07a5a83e34d11a2a106780056bfaf
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Hello there!

I just noticed you have the wrong checksum for `NODE_CHECKSUM_ARM64`, so I updated it to the correct one:

```sh
curl -s https://nodejs.org/dist/v24.6.0/SHASUMS256.txt | grep "node-v24.6.0-linux-arm64.tar.xz"

# > e514b8b0fa389c10fe3f4278c68fae03df4b7ba61bbde6cae936de3f6ca3b17c
```

After that, I couldn't launch the project because the current Fedora image only supports x64. I found the actual manifest for version 42:
```sh
skopeo inspect --raw docker://registry.fedoraproject.org/fedora:42
```

<details>
<summary>Result</summary>

```json
{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "manifests": [
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "digest": "sha256:e74d8168e5ebdaa9de404bde578168e9d0ae3ce6107d5cf93a00e88a74687246",
            "size": 572,
            "platform": {
                "architecture": "arm64",
                "os": "linux"
            }
        },
        ...
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "digest": "sha256:95b9d323caac38c099f4a6301e18f2b17277303987077cd4060de18b019ecfd0",
            "size": 572,
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            }
        }
    ]
}
```
</details>

I verified that the manifest supports all the necessary architectures and obtained its SHA-256 hash:
```sh
skopeo inspect --raw docker://registry.fedoraproject.org/fedora:42 | \
  sha256sum
  
# > 5a17ac8b773eac120d5f46316b196f5f6bb07a5a83e34d11a2a106780056bfaf
```

Everything works correctly on my end, but I'd appreciate if someone else could test this on x64 architecture, since my testing was exclusively performed on ARM64 🙏 