### PR TITLE
Fix syntax highlighting for .cjs/.mjs/.cts/.mts module files

### DIFF
--- a/web/ui/diff.svelte
+++ b/web/ui/diff.svelte
@@ -18,6 +18,11 @@
       colorScheme: ($darkStore ? 'dark' : 'light') as ColorSchemeType,
       drawFileList: false,
       highlight: true,
+      highlightLanguages: {
+        cjs: 'javascript',
+        cts: 'typescript',
+        mts: 'typescript'
+      },
       maxLineLengthHighlight: 5000,
       renderNothingWhenEmpty: true,
       stickyFileHeaders: true


### PR DESCRIPTION
Solving #43 