### PR TITLE
fix(yarn): parse grouped lockfile keys resolving to one version

### DIFF
--- a/server/loader/versions/yarn.ts
+++ b/server/loader/versions/yarn.ts
@@ -52,6 +52,7 @@ function parseYarn1Lock(content: string): ParsedDependency[] {
     let entryData = entries[entry]
     if (!entryData?.version) continue
 
+    // Yarn 1 format: @scope/package@^1.0.0 or package@^1.0.0
     // Every descriptor in a Yarn Classic group shares one package.
     let [first] = entry.split(', ')
     let { name } = splitPackage(first ?? entry)
@@ -89,6 +90,7 @@ function parseYarnBerryLock(content: string): ParsedDependency[] {
           ? value.resolution
           : undefined
 
+      // Yarn Berry format: "package@npm:1.0.0" or "@scope/package@npm:1.0.0"
       // Yarn Berry keeps one resolution locator for grouped descriptors.
       let name = splitPackage(resolved ?? key).name
       if (!name) continue

--- a/server/loader/versions/yarn.ts
+++ b/server/loader/versions/yarn.ts
@@ -52,8 +52,9 @@ function parseYarn1Lock(content: string): ParsedDependency[] {
     let entryData = entries[entry]
     if (!entryData?.version) continue
 
-    // Yarn 1 format: @scope/package@^1.0.0 or package@^1.0.0
-    let { name } = splitPackage(entry)
+    // Every descriptor in a Yarn Classic group shares one package.
+    let [first] = entry.split(', ')
+    let { name } = splitPackage(first ?? entry)
     if (!name) continue
 
     dependencies.push({

--- a/server/loader/versions/yarn.ts
+++ b/server/loader/versions/yarn.ts
@@ -83,16 +83,18 @@ function parseYarnBerryLock(content: string): ParsedDependency[] {
       'version' in value &&
       typeof value.version === 'string'
     ) {
-      // Yarn Berry format: "package@npm:1.0.0" or "@scope/package@npm:1.0.0"
-      let name = splitPackage(key).name
+      let resolved =
+        'resolution' in value && typeof value.resolution === 'string'
+          ? value.resolution
+          : undefined
+
+      // Yarn Berry keeps one resolution locator for grouped descriptors.
+      let name = splitPackage(resolved ?? key).name
       if (!name) continue
 
       dependencies.push({
         name,
-        resolved:
-          'resolution' in value && typeof value.resolution === 'string'
-            ? value.resolution
-            : undefined,
+        resolved,
         version: value.version
       })
     }

--- a/server/test/yarn.test.ts
+++ b/server/test/yarn.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { loadedFile } from '../../common/types.ts'
+import { yarn } from '../loader/versions/yarn.ts'
+
+test('parses grouped Yarn Berry keys resolving to one version', () => {
+  assert.deepEqual(
+    yarn.load([
+      loadedFile(
+        '/project/package.json',
+        JSON.stringify({
+          dependencies: { 'caniuse-lite': '^1.0.30001702' }
+        })
+      ),
+      loadedFile(
+        '/project/yarn.lock',
+        [
+          '__metadata:',
+          '  version: 8',
+          '  cacheKey: 10c0',
+          '"caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001746":',
+          '  version: 1.0.30001750',
+          '  resolution: "caniuse-lite@npm:1.0.30001750"',
+          '  languageName: node',
+          '  linkType: hard'
+        ].join('\n')
+      )
+    ]),
+    [
+      {
+        direct: true,
+        from: 'yarn',
+        name: 'caniuse-lite',
+        source: '/project/yarn.lock',
+        type: 'npm',
+        version: '1.0.30001750'
+      }
+    ]
+  )
+})

--- a/server/test/yarn.test.ts
+++ b/server/test/yarn.test.ts
@@ -39,3 +39,26 @@ test('parses grouped Yarn Berry keys resolving to one version', () => {
     ]
   )
 })
+
+test('parses grouped quoted scoped Yarn Classic keys', () => {
+  assert.deepEqual(
+    yarn.load([
+      loadedFile(
+        '/project/yarn.lock',
+        ['"@scope/pkg@^1.0.0", "@scope/pkg@^2.0.0":', '  version "2.1.0"'].join(
+          '\n'
+        )
+      )
+    ]),
+    [
+      {
+        direct: false,
+        from: 'yarn',
+        name: '@scope/pkg',
+        source: '/project/yarn.lock',
+        type: 'npm',
+        version: '2.1.0'
+      }
+    ]
+  )
+})


### PR DESCRIPTION
Yarn writes several descriptors that resolve to the same package as one comma-separated lockfile entry:

```
"caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001746": <------------ this
      version: 1.0.30001750
      resolution: "caniuse-lite@npm:1.0.30001750"
```

Loader gives this whole string to `splitPackage`. It looks for last `@`, but does not know about comma, so it cuts in wrong place and returns `caniuse-lite@^1.0.30001702, caniuse-lite`. This is not real package so registry returns an error.

Fix is to read the name from the package that was actually installed.

- Berry: use the `resolution` locator, not the key.
- yarn classic: no locator, so use the first descriptor; the group shares one ident.

Read more at #55. 

Fixes #55